### PR TITLE
Fixing missing dependencies for ruff.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM python:3.8.5-alpine
+FROM python:3.10.13-alpine3.19
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache \
     build-base \
+    cargo \
     postgresql-dev \
-    postgresql-libs
+    postgresql-libs \
+    rust
 
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
It's not my favorite long-term that the production image relies on the dev-packages (like ruff), but for now it's fine.

Side note:  I did a reset on my main branch and then pulled in the parent repo changes again, then re-applied these changes.

This is basically work to make the Docker image build again, which is, as always, available at akbarthegreat/splat-storage-discord:latest