### PR TITLE
Fix hunt end

### DIFF
--- a/bot/base_cog.py
+++ b/bot/base_cog.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+import discord
 from discord.ext import commands
 
 from bot import database
@@ -69,6 +70,20 @@ class BaseCog(commands.Cog):
                 f"Unable to retrieve puzzle={puzzle_id} round={round_id} {round_name}/{puzzle_name}"
             )
             return None
+
+    async def _error_if_not_bot_channel(
+        self, interaction: discord.Interaction, command: str, message: Optional[str] = None
+    ) -> bool:
+        if not (await self.check_is_bot_channel(interaction)):
+            settings = await database.query_guild(interaction.guild.id)
+            error_message = (
+                f"Can only use /{command} command in channel: {settings.discord_bot_channel}"
+            )
+            if message:
+                error_message += f" {message}"
+            await interaction.response.send_message(error_message)
+            return True
+        return False
 
 
 class GeneralAppError(RuntimeError):

--- a/bot/cogs/channel_management.py
+++ b/bot/cogs/channel_management.py
@@ -74,20 +74,6 @@ class ChannelManagement(BaseCog):
         """*Create new puzzle round: /round round-name*"""
         await self.create_round(interaction, category_name, hunt_name)
 
-    async def _error_if_not_bot_channel(
-        self, interaction: discord.Interaction, command: str, message: Optional[str] = None
-    ) -> bool:
-        if not (await self.check_is_bot_channel(interaction)):
-            settings = await database.query_guild(interaction.guild.id)
-            error_message = (
-                f"Can only use /{command} command in channel: {settings.discord_bot_channel}"
-            )
-            if message:
-                error_message += f" {message}"
-            await interaction.response.send_message(error_message)
-            return True
-        return False
-
     @app_commands.command()
     async def hunt(self, interaction: discord.Interaction, *, hunt_url: str, hunt_name: str):
         """*Create a new hunt*"""

--- a/bot/cogs/channel_management.py
+++ b/bot/cogs/channel_management.py
@@ -105,24 +105,6 @@ class ChannelManagement(BaseCog):
             await gsheet_cog.create_hunt_drive(interaction.guild.id, text_channel, settings)
 
     @app_commands.command()
-    async def hunt_end(
-        self, interaction: discord.Interaction, *, hunt_name: str, is_ended: bool = True
-    ):
-        """End the hunt. Note that puzzle channel creation etc may no longer work afterwards"""
-        if await self._error_if_not_bot_channel(interaction, "hunt_end"):
-            return
-
-        settings = await database.query_hunt_settings_by_name(
-            interaction.guild.id, hunt_name, allow_create=False
-        )
-        if is_ended:
-            await settings.update(end_time=datetime.datetime.now(tz=pytz.UTC)).apply()
-            await interaction.response.send_message(f"Have ended hunt: {hunt_name}. Congrats!")
-        else:
-            await settings.update(end_time=None).apply()
-            await interaction.response.send_message(f"Have un-ended hunt: {hunt_name}")
-
-    @app_commands.command()
     async def create_hunt_drive(self, interaction: discord.Interaction):
         hunt = await database.query_hunt_settings_by_round(
             interaction.guild.id, interaction.channel.category.id

--- a/bot/cogs/hunt_management.py
+++ b/bot/cogs/hunt_management.py
@@ -1,9 +1,11 @@
+import datetime
 import logging
 from typing import Optional
 
 import discord
 from discord import app_commands
 from discord.ext import commands
+import pytz
 
 from bot.base_cog import BaseCog
 from bot import database

--- a/bot/cogs/hunt_management.py
+++ b/bot/cogs/hunt_management.py
@@ -68,6 +68,25 @@ class HuntManagement(BaseCog):
                 f":exclamation: Unrecognized setting key: `{setting_key}`. Use `/show_hunt_settings` for more info."
             )
 
+    @app_commands.command()
+    async def hunt_end(
+        self, interaction: discord.Interaction, *, hunt_name: str, is_ended: bool = True
+    ):
+        """End the hunt. Note that puzzle channel creation etc may no longer work afterwards"""
+        if await self._error_if_not_bot_channel(interaction, "hunt_end"):
+            return
+
+        settings = await database.query_hunt_settings_by_name(
+            interaction.guild.id, hunt_name, allow_create=False
+        )
+        if is_ended:
+            await settings.update(end_time=datetime.datetime.now(tz=pytz.UTC)).apply()
+            await interaction.response.send_message(f"Have ended hunt: {hunt_name}. Congrats!")
+        else:
+            await settings.update(end_time=None).apply()
+            await interaction.response.send_message(f"Have un-ended hunt: {hunt_name}")
+
+
 
 async def setup(bot):
     await bot.add_cog(HuntManagement(bot))

--- a/bot/database/__init__.py
+++ b/bot/database/__init__.py
@@ -33,7 +33,7 @@ async def query_hunt_settings_by_name(guild_id: int, hunt_name: str, allow_creat
     if allow_create:
         return await models.HuntSettings.get_or_create_by_name(guild_id, hunt_name)
     else:
-        return models.HuntSettings.query.where(
+        return await models.HuntSettings.query.where(
             (models.HuntSettings.guild_id == guild_id)
             & (models.HuntSettings.hunt_name == hunt_name)
         ).gino.first()


### PR DESCRIPTION
hunt_end had a bug I fixed (mostly a coroutine that wasn't awaited, it's so easy to do). -- adding that await is the only truly _crucial_ part of this whole thing now.

I moved it to hunt_management, to be more consistent with the intent behind that split of functionality and moved the bot channel check to the base cog (I fixed the missing default value bug there in parallel to you -- oops).

NB:  One thing I'd like to do is move a lot of channel management logic out of the cogs and into a library and then the cogs can be more directly focused on whether they deal with puzzles, rounds, or the hunt (and the cog file can avoid being 800 lines long).  I may or may not ever get around to doing that, but it was on my list for my fork as a long-term maintenance improvement.