### PR TITLE
Fixing a typo, adding stat/stop times when we show hunt settings.

### DIFF
--- a/bot/cogs/hunt_management.py
+++ b/bot/cogs/hunt_management.py
@@ -40,7 +40,7 @@ class HuntManagement(BaseCog):
     @commands.has_permissions(manage_channels=True)
     @app_commands.command()
     async def show_hunt_settings(self, interaction: discord.Interaction):
-        """*(admin) Show guild-level settings*"""
+        """*(admin) Show hunt-level settings*"""
         settings = await self._get_hunt_settings_from_channel(interaction)
         if not settings:
             return


### PR DESCRIPTION
The typo is an obvious fix.  I'm not as certain about the hunt_settings change -- on the one hand, I think it's nice to be able to see what those values are.  On the other, it implies you should be able to set them with the /update_hunt_setting command, which I don't think you should.  I erred on the side of "show more data" but I acknowledge that this is a judgment call sort of thing.