### PR TITLE
Docker-based development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+   "name": "Dev Container",
+   "dockerFile": "../Dockerfile",
+   "build": {
+      "target": "devtools"
+   },
+   "runArgs": [
+      "--network=host"
+   ],
+   "customizations": {
+      "vscode": {
+         "settings": {
+            "python.defaultInterpreterPath": "/usr/local/bin/python",
+            "python.testing.pytestArgs": [
+               "tests"
+            ],
+            "python.testing.unittestEnabled": false,
+            "python.testing.pytestEnabled": true
+         },
+         "extensions": [
+            "ms-python.python",
+            "ms-python.pylance",
+            "ms-python.vscode-pylance",
+            "ms-python.flake8",
+            "ms-python.black-formatter",
+            "ms-python.isort"
+         ]
+      }
+   },
+   "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,6 @@ dmypy.json
 .pyre/
 
 # vscode
-.vscode/*
 *.code-workspace
 
 # TEMPLATE END

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+   "python.testing.pytestArgs": [
+      "tests"
+   ],
+   "python.testing.unittestEnabled": false,
+   "python.testing.pytestEnabled": true
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.10.13-alpine3.19
+#-------------------------------------------------------------------------------
+# Base image contains most everything needed to run the server
+#-------------------------------------------------------------------------------
+FROM python:3.10.13-alpine3.19 as base
 ENV PYTHONUNBUFFERED 1
 
 RUN apk add --no-cache \
     build-base \
-    cargo \
     postgresql-dev \
-    postgresql-libs \
-    rust
+    postgresql-libs
 
 RUN mkdir /code
 WORKDIR /code
@@ -15,7 +16,6 @@ RUN pip install pipenv
 
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock
-RUN pipenv install --system
 
 COPY ./docker_entrypoint.sh docker_entrypoint.sh
 COPY ./alembic.ini alembic.ini
@@ -23,5 +23,22 @@ COPY ./run.py run.py
 COPY ./alembic alembic
 COPY ./bot bot
 
+#-------------------------------------------------------------------------------
+# Devtools contains linters or autoformatters which aren't needed in production
+#-------------------------------------------------------------------------------
+FROM base as devtools
+
+RUN pipenv install --system --dev
+
+CMD "echo No default command"
+
+#-------------------------------------------------------------------------------
+# The server image installs locked dependencies, then runs the bot.
+#-------------------------------------------------------------------------------
+FROM base as server 
+
+RUN pipenv install --system
+
 CMD ./docker_entrypoint.sh
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Base image contains most everything needed to run the server
+# Base image contains the core dependencies for running a server
 #-------------------------------------------------------------------------------
 FROM python:3.10.13-alpine3.19 as base
 ENV PYTHONUNBUFFERED 1
@@ -17,12 +17,6 @@ RUN pip install pipenv
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock
 
-COPY ./docker_entrypoint.sh docker_entrypoint.sh
-COPY ./alembic.ini alembic.ini
-COPY ./run.py run.py
-COPY ./alembic alembic
-COPY ./bot bot
-
 #-------------------------------------------------------------------------------
 # Devtools contains linters or autoformatters which aren't needed in production
 #-------------------------------------------------------------------------------
@@ -33,9 +27,15 @@ RUN pipenv install --system --dev
 CMD "echo No default command"
 
 #-------------------------------------------------------------------------------
-# The server image installs locked dependencies, then runs the bot.
+# The server image installs the code, locked dependencies, then runs the bot.
 #-------------------------------------------------------------------------------
 FROM base as server 
+
+COPY ./docker_entrypoint.sh docker_entrypoint.sh
+COPY ./alembic.ini alembic.ini
+COPY ./run.py run.py
+COPY ./alembic alembic
+COPY ./bot bot
 
 RUN pipenv install --system
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ COPY Pipfile.lock Pipfile.lock
 #-------------------------------------------------------------------------------
 FROM base AS devtools
 
+RUN apk add --no-cache \
+    git
+
 RUN pipenv install --system --dev
 
 CMD ["/bin/echo", "No default command"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 #-------------------------------------------------------------------------------
 # Base image contains the core dependencies for running a server
 #-------------------------------------------------------------------------------
-FROM python:3.10.13-alpine3.19 as base
-ENV PYTHONUNBUFFERED 1
+FROM python:3.10.13-alpine3.19 AS base
+ENV PYTHONUNBUFFERED=1
 
 RUN apk add --no-cache \
     build-base \
@@ -20,16 +20,16 @@ COPY Pipfile.lock Pipfile.lock
 #-------------------------------------------------------------------------------
 # Devtools contains linters or autoformatters which aren't needed in production
 #-------------------------------------------------------------------------------
-FROM base as devtools
+FROM base AS devtools
 
 RUN pipenv install --system --dev
 
-CMD "echo No default command"
+CMD ["/bin/echo", "No default command"]
 
 #-------------------------------------------------------------------------------
 # The server image installs the code, locked dependencies, then runs the bot.
 #-------------------------------------------------------------------------------
-FROM base as server 
+FROM base AS server 
 
 COPY ./docker_entrypoint.sh docker_entrypoint.sh
 COPY ./alembic.ini alembic.ini
@@ -39,6 +39,6 @@ COPY ./bot bot
 
 RUN pipenv install --system
 
-CMD ./docker_entrypoint.sh
+CMD ["./docker_entrypoint.sh"]
 
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -505,11 +505,11 @@
         },
         "mako": {
             "hashes": [
-                "sha256:57d4e997349f1a92035aa25c17ace371a4213f2ca42f99bee9a602500cfd54d9",
-                "sha256:e3a9d388fd00e87043edbe8792f45880ac0114e9c4adc69f6e9bfb2c55e3b11b"
+                "sha256:2a0c8ad7f6274271b3bb7467dd37cf9cc6dab4bc19cb69a4ef10669402de698e",
+                "sha256:32a99d70754dfce237019d17ffe4a282d2d3351b9c476e90d8a60e63f133b80c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.3.0"
+            "version": "==1.3.2"
         },
         "markupsafe": {
             "hashes": [
@@ -869,11 +869,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3",
-                "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"
+                "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20",
+                "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         },
         "yarl": {
             "hashes": [
@@ -1237,27 +1237,27 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:1c8eca1a47b4150dc0fbec7fe68fc91c695aed798532a18dbb1424e61e9b721f",
-                "sha256:2270504d629a0b064247983cbc495bed277f372fb9eaba41e5cf51f7ba705a6a",
-                "sha256:269302b31ade4cde6cf6f9dd58ea593773a37ed3f7b97e793c8594b262466b67",
-                "sha256:62ce2ae46303ee896fc6811f63d6dabf8d9c389da0f3e3f2bce8bc7f15ef5488",
-                "sha256:653230dd00aaf449eb5ff25d10a6e03bc3006813e2cb99799e568f55482e5cae",
-                "sha256:6b3dadc9522d0eccc060699a9816e8127b27addbb4697fc0c08611e4e6aeb8b5",
-                "sha256:7060156ecc572b8f984fd20fd8b0fcb692dd5d837b7606e968334ab7ff0090ab",
-                "sha256:722bafc299145575a63bbd6b5069cb643eaa62546a5b6398f82b3e4403329cab",
-                "sha256:80258bb3b8909b1700610dfabef7876423eed1bc930fe177c71c414921898efa",
-                "sha256:87b3acc6c4e6928459ba9eb7459dd4f0c4bf266a053c863d72a44c33246bfdbf",
-                "sha256:96f76536df9b26622755c12ed8680f159817be2f725c17ed9305b472a757cdbb",
-                "sha256:a53d8e35313d7b67eb3db15a66c08434809107659226a90dcd7acb2afa55faea",
-                "sha256:ab3f71f64498c7241123bb5a768544cf42821d2a537f894b22457a543d3ca7a9",
-                "sha256:ad3f8088b2dfd884820289a06ab718cde7d38b94972212cc4ba90d5fbc9955f3",
-                "sha256:b2027dde79d217b211d725fc833e8965dc90a16d0d3213f1298f97465956661b",
-                "sha256:bea9be712b8f5b4ebed40e1949379cfb2a7d907f42921cf9ab3aae07e6fba9eb",
-                "sha256:e3d241aa61f92b0805a7082bd89a9990826448e4d0398f0e2bc8f05c75c63d99"
+                "sha256:1bab866aafb53da39c2cadfb8e1c4550ac5340bb40300083eb8967ba25481447",
+                "sha256:2417e1cb6e2068389b07e6fa74c306b2810fe3ee3476d5b8a96616633f40d14f",
+                "sha256:3837ac73d869efc4182d9036b1405ef4c73d9b1f88da2413875e34e0d6919587",
+                "sha256:5fe8d54df166ecc24106db7dd6a68d44852d14eb0729ea4672bb4d96c320b7df",
+                "sha256:6c629cf64bacfd136c07c78ac10a54578ec9d1bd2a9d395efbee0935868bf852",
+                "sha256:6f0bfbb53c4b4de117ac4d6ddfd33aa5fc31beeaa21d23c45c6dd249faf9126f",
+                "sha256:6f8ad828f01e8dd32cc58bc28375150171d198491fc901f6f98d2a39ba8e3ff5",
+                "sha256:86811954eec63e9ea162af0ffa9f8d09088bab51b7438e8b6488b9401863c25e",
+                "sha256:9405fa9ac0e97f35aaddf185a1be194a589424b8713e3b97b762336ec79ff807",
+                "sha256:9a933dfb1c14ec7a33cceb1e49ec4a16b51ce3c20fd42663198746efc0427360",
+                "sha256:abf4822129ed3a5ce54383d5f0e964e7fef74a41e48eb1dfad404151efc130a2",
+                "sha256:b17b93c02cdb6aeb696effecea1095ac93f3884a49a554a9afa76bb125c114c1",
+                "sha256:c66ec24fe36841636e814b8f90f572a8c0cb0e54d8b5c2d0e300d28a0d7bffec",
+                "sha256:ddb87643be40f034e97e97f5bc2ef7ce39de20e34608f3f829db727a93fb82c5",
+                "sha256:e0d432aec35bfc0d800d4f70eba26e23a352386be3a6cf157083d18f6f5881c8",
+                "sha256:f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e",
+                "sha256:fd4025ac5e87d9b80e1f300207eb2fd099ff8200fa2320d7dc066a3f4622dc6b"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.1.14"
+            "version": "==0.1.15"
         },
         "stack-data": {
             "hashes": [

--- a/dev/ruff.sh
+++ b/dev/ruff.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+REPO_TOP=$(dirname -- "$(dirname -- "$( readlink -f -- "$0"; )"; )"; )
+
+cd ${REPO_TOP}
+
+if [[ -z $@ ]]; then
+    ARGS="check --fix"
+else
+    ARGS=$@
+fi
+
+docker buildx build --target=devtools -t splat-bot-devtools .
+docker run --rm -v ${REPO_TOP}:/code -it splat-bot-devtools sh -c "ruff ${ARGS}"
+

--- a/dev/update-pipenv-lock.sh
+++ b/dev/update-pipenv-lock.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+REPO_TOP=$(dirname -- "$(dirname -- "$( readlink -f -- "$0"; )"; )"; )
+
+cd ${REPO_TOP}
+
+docker buildx build --target=devtools -t splat-bot-devtools .
+docker run --rm -it splat-bot-devtools sh -c "pipenv lock > /dev/null 2>&1 && cat Pipfile.lock" > Pipfile.lock
+

--- a/update-pipenv-lock.sh
+++ b/update-pipenv-lock.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-docker buildx build -t pipenv_update .
-docker run --rm -it pipenv_update sh -c "pipenv lock > /dev/null 2>&1 && cat Pipfile.lock" > Pipfile.lock
-


### PR DESCRIPTION
I've set up the infrastructure to use a devcontainer.

Restructured the Dockerfile to allow for a target that builds our image with a bunch of dev packages and python tooling added.

Then, add the configuration file for a devcontainer, so vscode can open the project in that container instead of natively, if someone wants it.  This allows for VSCode to run tests/ruff/etc. all natively as if you had everything installed exactly the way the tool wants it.